### PR TITLE
Migrate hosting to Vercel and switch to clean URL routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.vercel

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.renanbazinin.com

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": false,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://renanbazinin.github.io/",
+  "homepage": "https://renanbazinin.com",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,6 +57,7 @@ function App() {
             <Route path="/projects" element={<Projects />} />
             <Route path="/timeline" element={<Timeline />} />
             <Route path="/about" element={<AboutMe />} />
+            <Route path="*" element={<Home />} />
           </Routes>
         </motion.div>
       </main>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,18 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { HashRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
+// Legacy links from the previous HashRouter (/#/projects) → clean paths (/projects)
+if (window.location.hash.startsWith('#/')) {
+  window.history.replaceState(null, '', window.location.hash.slice(1))
+}
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <HashRouter>
+    <BrowserRouter>
       <App />
-    </HashRouter>
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Why

`renanbazinin.com` was attached to the **user** Pages repo, so GitHub served all 50 project repos under that one hostname — `renanbazinin.github.io/myTV/` 301'd to `renanbazinin.com/myTV/`. Safe Browsing classifies at host level, so a flag on any single experiment took the portfolio down with it. Chrome was showing a full-page "Dangerous site" warning.

This moves the portfolio to Vercel so the apex domain serves only this site, and the experiments stay isolated on `github.io`.

## Changes

**Routing — `HashRouter` → `BrowserRouter`**
URLs become `/projects` instead of `/#/projects`. Google indexes hash fragments poorly, which matters now that the site is registered in Search Console. Legacy `#/...` links are rewritten to clean paths on load, so shared links keep working.

A catch-all `<Route path="*">` is added. The Vercel rewrite serves `index.html` for every path, so without it any unmatched URL would render an empty page instead of a 404.

**`vercel.json`** — Vite framework, SPA rewrite, and baseline security headers (`X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`).

**`CNAME` deleted** — with DNS pointing at Vercel, a lingering CNAME file makes GitHub keep claiming the domain. This also retires a real bug: `gh-pages -d dist` replaces the branch wholesale, so every `npm run deploy` deleted `CNAME`, unbound the domain, and forced a Let's Encrypt re-provision. That is visible in the `gh-pages` history as alternating `Create CNAME` / `Updates` commits, and it was surfacing as intermittent certificate warnings after each deploy.

## Verification

- `npm run lint` — clean
- `npm run build` — 2030 modules, 405 KB → 128 KB gzip
- DNS confirmed: apex → `76.76.21.21`, `www` → `cname.vercel-dns.com`
- `renanbazinin.github.io/myTV/` returns 200 with no redirect — isolation confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzJRiUoeCKiAPhW5ftSuh7